### PR TITLE
fix: testimonial href

### DIFF
--- a/src/lib/testimonials.svelte
+++ b/src/lib/testimonials.svelte
@@ -14,7 +14,7 @@ export let styles = ''
     <blockquote class="text-base mt-4 md:text-2xl md:mt-16">
     hyper enables us to spend time on what matters. By providing a well-defined interface for things like data persistence, caching, and search, hyper allows us to avoid bike-shedding and reinventing logic that is common across the majority of our applications. Instead, we can spend our time working on the details that make each project unique and keep our focus on providing value to the customer. 
     </blockquote>
-    <p class="mt-4 md:mt-8">Travis Nesland, Senior Lead Developer at <a class="text-blue" href="https://sovereign.com">Sovereign, co.</a></p>
+    <p class="mt-4 md:mt-8">Travis Nesland, Senior Lead Developer at <a class="text-blue" href="https://sovereign.co">Sovereign, co.</a></p>
     <!--
     <Pagination styles="mt-4 justify-center md:justify-start md:mt-16" pages=3 />
     -->


### PR DESCRIPTION
Change the `href` in the testimonial from `sovereign.com` to `sovereign.co`.

We're not cool enough to have a `.com` :stuck_out_tongue_closed_eyes: 