### PR TITLE
Tripott/bugs reported by chris 22

### DIFF
--- a/src/lib/all-n-one.svelte
+++ b/src/lib/all-n-one.svelte
@@ -7,7 +7,7 @@
   <h5>HYPER POWER</h5>
   <h1 class="text-4xl mt-4 md:text-6xl md:mt-16">All-In-One</h1>
   <p class="mt-4 text-base md:text-2xl md:mt-12 md:w-1/2 text-center">hyper contains all of the services primitives to build applications without having to deal with servers, services or clouds.</p>
-  <a href="https://docs.hyper63.com/getting-started"><Button styles="mt-16 mb-24">Get Started</Button></a>
+  <a href="https://docs.hyper.io/getting-started"><Button styles="mt-16 mb-24">Get Started</Button></a>
   <img src="/all.svg" alt="hyper framework" />
 </section>
 

--- a/src/lib/button.svelte
+++ b/src/lib/button.svelte
@@ -4,12 +4,13 @@
   export let txtColor = 'white'
   export let styles = ''
   export let hyperBolt = true
+  export let hoverBgColor ='purple'
     
   </script>
   <button 
     on:click 
     type={type} 
-    class="space-x-4 text-{txtColor} bg-{bgColor} hover:bg-light{bgColor} focus:ring-{bgColor} {styles}">
+    class="space-x-4 text-{txtColor} bg-{bgColor} hover:bg-{hoverBgColor} focus:ring-{bgColor} {styles}">
       <div>
         <slot></slot>
       </div>

--- a/src/lib/footer.svelte
+++ b/src/lib/footer.svelte
@@ -33,8 +33,8 @@
     <div class="p-16">
       <div class="mb-8 text-blue">CONTACT</div>
       <ul>
-        <li><a href="mailto:info@hyper.io">INFO@HYPER63.COM</a></li>
-        <li><a href="mailto:support@hyper.io">SUPPORT@HYPER63.COM</a></li>
+        <li><a href="mailto:info@hyper.io">INFO@HYPER.IO</a></li>
+        <li><a href="mailto:support@hyper.io">SUPPORT@HYPER.IO</a></li>
         <li><a href="https://twitter.com/_hyper_io">TWITTER</a></li>
         <li><a href="https://github.com/hyper63">GITHUB</a></li>
       </ul>

--- a/src/routes/faq.svelte
+++ b/src/routes/faq.svelte
@@ -30,7 +30,7 @@
   <h1 class="mt-8 mx-auto text-5xl text-center md:text-6xl">FAQs</h1> 
   <p class="mt-4 px-4 text-base text-darkgray md:text-center">
   Can’t find the answer you’re looking for? Reach out to our 
-  <a href="/contact" class="text-red underline">customer support team</a>.
+  <a href="https://github.com/hyper63/hyper63/discussions" class="text-red underline">customer support team</a>.
   </p>
   {#if flags.search}
   <section class="mt-4 mx-4 md:flex md:justify-center">


### PR DESCRIPTION
- contact URL changed to `hyper.io`
- getting started button bg hover color defaulted to purple and set up as `Button` prop `export let hoverBgColor ='purple'`
- FAQ customer support team link changed to `https://github.com/hyper63/hyper63/discussions`.

![ROADHOUSE!](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%3Fid%3DOIP.mLTvvYOw79mCGRYS91O8NgHaGu%26pid%3DApi&f=1)