### PR TITLE
feat: add where does hyper fit section

### DIFF
--- a/src/lib/where-hyper-fits.svelte
+++ b/src/lib/where-hyper-fits.svelte
@@ -1,0 +1,29 @@
+<script>
+  import { onMount } from "svelte";
+
+  export let styles = "";
+
+  let img;
+  const src = "/hyper-stack.gif";
+
+  /**
+   * The src gif is fairly large
+   * so we defer loading it until after the page has loaded
+   * to prevent blocking
+   */
+  onMount(() => {
+    img.setAttribute("src", src);
+  });
+</script>
+
+<section class="flex flex-col items-center py-16 md:py-12 w-full bg-white {styles}">
+  <h2 class="text-2xl font-semibold md:text-5xl md:mt-16">Where does hyper fit?</h2>
+  <p class="w-full max-w-3xl mt-4 text-center">
+    hyper services power your backend business services. Hyper's consistent API makes it simple to
+    consume cloud native services, and without coupling. Focus on your business services, not
+    plubming in the cloud.
+  </p>
+  <div class="hidden mt-8 md:block md:w-full max-w-5xl">
+    <img bind:this={img} data-src={src} alt="where does hyper fit graphic" />
+  </div>
+</section>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -130,7 +130,7 @@
       <img class="w-4/5 m-auto" src="/flow1.svg" alt="flow" />
     </div>
   </div>
-  <Ports {examples} styles="pl-12 pr-12" />
+  <Ports {examples} styles="pl-12 pr-12 bg-white py-12" />
   <Composition example={examples.composition} styles="pl-12 pr-12" />
   <WhereHyperFits styles="px-4 md:pl-24 md:pr-24" />
   <All styles="px-4 md:pl-24 md:pr-24" />

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -39,6 +39,7 @@
   import Header from "$lib/header.svelte";
   import Ports from "$lib/ports.svelte";
   import All from "$lib/all-n-one.svelte";
+  import WhereHyperFits from "$lib/where-hyper-fits.svelte";
   import FAQs from "$lib/faqs.svelte";
   import Testimonials from "$lib/testimonials.svelte";
   import YouTubePromo from "$lib/hyper-promo-video-hero.svelte";
@@ -131,6 +132,7 @@
   </div>
   <Ports {examples} styles="pl-12 pr-12" />
   <Composition example={examples.composition} styles="pl-12 pr-12" />
+  <WhereHyperFits styles="px-4 md:pl-24 md:pr-24" />
   <All styles="px-4 md:pl-24 md:pr-24" />
   <FAQs {faqs} />
   <Testimonials styles="px-4 md:pl-24 md:pr-24" />


### PR DESCRIPTION
Animated gif that shows hyper replacing cloud services maze.

![Screen Shot 2022-05-09 at 1 43 10 PM](https://user-images.githubusercontent.com/8246360/167466898-82f16698-0f04-46ed-8a4a-888bec161dab.png)


TODO: should we store the gif not in the repo?