### PR TITLE
feat: add learn more section

### DIFF
--- a/src/lib/all-n-one.svelte
+++ b/src/lib/all-n-one.svelte
@@ -6,7 +6,7 @@
   export let styles = "";
 </script>
 
-<section class="flex flex-col items-center mt-16 md:mt-12 w-full {styles}">
+<section class="flex flex-col items-center my-16 md:my-12 w-full {styles}">
   <h5>HYPER POWER</h5>
   <h2 class="text-2xl font-semibold md:text-5xl md:mt-16">All-in-one</h2>
   <p class="w-full mt-4 md:mt-16 md:mt-12 lg:w-1/2 text-center">

--- a/src/lib/learn-more.svelte
+++ b/src/lib/learn-more.svelte
@@ -1,0 +1,63 @@
+<script>
+  import Arrow from "./svgs/arrow.svelte";
+  import Bolt from "./svgs/bolt.svelte";
+
+  export let styles = "";
+
+  const resources = [
+    {
+      title: "Getting Started",
+      description: "Build an Express API backed by hyper services in under 5 minutes",
+      href: "https://docs.hyper.io/getting-started",
+      imgComponent: Arrow,
+    },
+    {
+      title: `Workshops`,
+      description: "Follow video workshops that show how you can use hyper",
+      href: "https://docs.hyper.io/workshops",
+      imgComponent: Arrow,
+    },
+    {
+      title: `Quickstarts`,
+      description: "See examples on how you can leverage hyper services to create complex flows",
+      href: "https://docs.hyper.io/nodejs-quickstarts",
+      imgComponent: Arrow,
+    },
+    {
+      title: `<pre><code>hyper-connect</code></pre>`,
+      description:
+        "Use the hyper-connect SDK to seamlessly connect to hyper services on Node or Deno",
+      href: "https://docs.hyper.io/hyper-connect",
+      imgComponent: Bolt,
+    },
+    {
+      title: `Blog`,
+      description: "Keep up with all of the news and info from the hyper team",
+      href: "https://blog.hyper.io",
+      imgComponent: Bolt,
+    },
+  ];
+</script>
+
+<section class="flex flex-col items-center py-16 md:py-12 w-full {styles}">
+  <h2 class="text-2xl font-semibold md:text-5xl md:mt-16">
+    Learn About <span class="text-yellow">hyper</span>
+  </h2>
+  <div class="mx-auto max-w-7xl py-2 px-4 sm:px-6 lg:px-8">
+    <div class="mt-6 w-full grid grid-cols-1 md:grid-cols-3 gap-8">
+      {#each resources as resource}
+        <div class="w-full p-4">
+          <div class="text-yellow">
+            <a class="hover:underline" href={resource.href} target="_blank">
+              <div class="h-4 mb-1">
+                <svelte:component this={resource.imgComponent} />
+              </div>
+              <div>{@html resource.title}</div>
+            </a>
+          </div>
+          <p>{resource.description}</p>
+        </div>
+      {/each}
+    </div>
+  </div>
+</section>

--- a/src/lib/svgs/arrow.svelte
+++ b/src/lib/svgs/arrow.svelte
@@ -1,7 +1,11 @@
+<script>
+  export let color = "currentColor";
+</script>
+
 <svg width="14" height="12" viewBox="0 0 14 12" fill="none" xmlns="http://www.w3.org/2000/svg">
   <path
     d="M8 1L13 6M13 6L8 11M13 6H1"
-    stroke="white"
+    stroke={color}
     stroke-width="2"
     stroke-linecap="round"
     stroke-linejoin="round"

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -48,6 +48,7 @@
   import Bolt from "$lib/svgs/bolt.svelte";
 
   import { HelpURLs } from "$lib/constants.js";
+  import LearnMore from "$lib/learn-more.svelte";
 
   export let faqs;
   export let examples;
@@ -134,6 +135,7 @@
   <Composition example={examples.composition} styles="pl-12 pr-12" />
   <WhereHyperFits styles="px-4 md:pl-24 md:pr-24" />
   <All styles="px-4 md:pl-24 md:pr-24" />
+  <LearnMore styles="px-4 md:pl-24 md:pr-24 bg-white" />
   <FAQs {faqs} />
   <Testimonials styles="px-4 md:pl-24 md:pr-24" />
 </main>


### PR DESCRIPTION
Add a "Learn About Hyper" section to the home page.

We probably need to find a place for the Remix stack and the eventual NextJS starter

![Screen Shot 2022-05-09 at 3 27 03 PM](https://user-images.githubusercontent.com/8246360/167483652-c685f008-7f98-45fd-99db-96a7cb76ca21.png)
![Screen Shot 2022-05-09 at 3 35 47 PM](https://user-images.githubusercontent.com/8246360/167484424-9ce10606-c17d-4d6f-89e3-e0997c49072f.png)

